### PR TITLE
:zap: Update feature - Picker library Part 4

### DIFF
--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/Constants.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/Constants.kt
@@ -2,3 +2,5 @@ package com.app.imagepickerlibrary
 
 internal const val dateFormatForTakePicture = "yyyyMMdd_HHmmss"
 internal const val EXTRA_IMAGE_PICKER_CONFIG = "extra-picker-config"
+internal const val MB_TO_BYTE_MULTIPLIER = 1e+6
+internal const val MAX_PICK_LIMIT = 15

--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/model/DataModels.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/model/DataModels.kt
@@ -3,6 +3,7 @@ package com.app.imagepickerlibrary.model
 import android.net.Uri
 import android.os.Parcelable
 import android.provider.MediaStore
+import com.app.imagepickerlibrary.MAX_PICK_LIMIT
 import com.app.imagepickerlibrary.toByteSize
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
@@ -17,8 +18,8 @@ internal data class PickerConfig(
     var showCountInToolBar: Boolean = true,
     var showFolders: Boolean = true,
     var allowMultipleSelection: Boolean = false,
-    var maxPickCount: Int = Int.MAX_VALUE,
-    var maxPickSizeMB: Int = Int.MAX_VALUE,
+    var maxPickCount: Int = MAX_PICK_LIMIT,
+    var maxPickSizeMB: Float = Float.MAX_VALUE,
     var pickExtension: PickExtension = PickExtension.ALL,
     var showCameraIconInGallery: Boolean = true,
     var isDoneIcon: Boolean = true,
@@ -40,7 +41,7 @@ internal data class PickerConfig(
     fun generateSelectionArguments(): Pair<String, Array<String>> {
         val selection: StringBuilder = StringBuilder()
         val selectionArgs = mutableListOf<String>()
-        if (maxPickSizeMB != Int.MAX_VALUE) {
+        if (maxPickSizeMB != Float.MAX_VALUE) {
             selection.append("${MediaStore.Images.Media.SIZE} <= ?")
             selectionArgs.add(maxPickSizeMB.toByteSize().toString())
         }

--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/activity/ImagePickerActivity.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/activity/ImagePickerActivity.kt
@@ -5,7 +5,6 @@ import android.content.ClipData
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
@@ -156,7 +155,7 @@ class ImagePickerActivity : AppCompatActivity(), View.OnClickListener {
     }
 
     private fun updateSelectCount() {
-        if (pickerConfig.showCountInToolBar && pickerConfig.allowMultipleSelection && pickerConfig.maxPickCount != Int.MAX_VALUE) {
+        if (pickerConfig.showCountInToolBar && pickerConfig.allowMultipleSelection) {
             binding.toolbar.textTitle.text =
                 getString(
                     R.string.str_selected_image_toolbar,

--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/adapter/BaseAdapter.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/adapter/BaseAdapter.kt
@@ -32,9 +32,14 @@ internal abstract class BaseAdapter<T>(protected val listener: ItemClickListener
 
     override fun getItemCount() = itemList.size
 
-    fun addItemList(list: List<T>) {
+    /**
+     * Clearing previous image list item and adding all the new items
+     * Using notifyDataSetChanged to manage both addition and removal of image items from list
+     */
+    fun setItemList(list: List<T>) {
+        itemList.clear()
         itemList.addAll(list)
-        notifyItemRangeInserted(itemList.size - list.size, list.size)
+        notifyDataSetChanged()
     }
 
     internal open inner class BaseVH(val binding: ViewDataBinding) :

--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/dialog/FullScreenImageDialogFragment.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/dialog/FullScreenImageDialogFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.DialogFragment
 import coil.load
 import com.app.imagepickerlibrary.R
 import com.app.imagepickerlibrary.databinding.DialogFragmentFullScreenImageBinding
+import com.app.imagepickerlibrary.getModel
 import com.app.imagepickerlibrary.model.Image
 
 /**
@@ -48,7 +49,7 @@ internal class FullScreenImageDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val image: Image? = arguments?.getParcelable(IMAGE)
+        val image: Image? = arguments?.getModel(IMAGE)
         if (image == null) {
             dismiss()
         }

--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/fragment/BaseFragment.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/fragment/BaseFragment.kt
@@ -1,5 +1,6 @@
 package com.app.imagepickerlibrary.ui.fragment
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -14,6 +15,10 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.app.imagepickerlibrary.R
+import com.app.imagepickerlibrary.getIntAttribute
 import com.app.imagepickerlibrary.listener.ItemClickListener
 import com.app.imagepickerlibrary.model.Image
 import com.app.imagepickerlibrary.model.Result
@@ -99,6 +104,27 @@ internal abstract class BaseFragment<Binding : ViewDataBinding, T> : Fragment(),
         }
         handleItemClick(item, position, viewId)
     }
+
+    /**
+     * Setting recycler view for both folder and image fragments.
+     * The span count is based on screen orientation so that the picker screen look better.
+     */
+    protected fun setRecyclerView(recyclerView: RecyclerView) {
+        val spanCount =
+            if (resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
+                requireContext().getIntAttribute(R.attr.ssPickerGridCount)
+            } else {
+                requireContext().getIntAttribute(R.attr.ssPickerGridCountLandscape)
+            }
+        recyclerView.layoutManager = GridLayoutManager(requireContext(), spanCount)
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        onConfigurationChange()
+    }
+
+    abstract fun onConfigurationChange()
 
     abstract fun handleItemClick(item: T, position: Int, viewId: Int)
 }

--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/fragment/FolderFragment.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/fragment/FolderFragment.kt
@@ -8,6 +8,7 @@ import com.app.imagepickerlibrary.R
 import com.app.imagepickerlibrary.databinding.FragmentFolderBinding
 import com.app.imagepickerlibrary.model.Folder
 import com.app.imagepickerlibrary.model.Image
+import com.app.imagepickerlibrary.model.Result
 import com.app.imagepickerlibrary.ui.adapter.FolderAdapter
 import kotlinx.coroutines.launch
 
@@ -26,6 +27,7 @@ internal class FolderFragment : BaseFragment<FragmentFolderBinding, Folder>() {
     override fun getLayoutResId(): Int = R.layout.fragment_folder
 
     override fun onViewCreated() {
+        setRecyclerView(binding.rvFolder)
         binding.rvFolder.adapter = folderAdapter
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.CREATED) {
@@ -39,10 +41,13 @@ internal class FolderFragment : BaseFragment<FragmentFolderBinding, Folder>() {
     }
 
     private fun updateFolderList(folderList: List<Folder>) {
+        if (viewModel.resultFlow.value is Result.Loading) {
+            return
+        }
         val isFolderListEmpty = folderList.isEmpty()
         binding.rvFolder.isVisible = !isFolderListEmpty
         binding.textNoData.isVisible = isFolderListEmpty
-        folderAdapter.addItemList(folderList)
+        folderAdapter.setItemList(folderList)
     }
 
     override fun handleSuccess(images: List<Image>) {
@@ -60,5 +65,9 @@ internal class FolderFragment : BaseFragment<FragmentFolderBinding, Folder>() {
 
     override fun handleItemClick(item: Folder, position: Int, viewId: Int) {
         viewModel.openFolder(item)
+    }
+
+    override fun onConfigurationChange() {
+        setRecyclerView(binding.rvFolder)
     }
 }

--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/fragment/ImageFragment.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/fragment/ImageFragment.kt
@@ -10,6 +10,7 @@ import com.app.imagepickerlibrary.databinding.FragmentImageBinding
 import com.app.imagepickerlibrary.getStringAttribute
 import com.app.imagepickerlibrary.model.Image
 import com.app.imagepickerlibrary.model.PickerConfig
+import com.app.imagepickerlibrary.model.Result
 import com.app.imagepickerlibrary.toast
 import com.app.imagepickerlibrary.ui.adapter.ImageAdapter
 import com.app.imagepickerlibrary.ui.dialog.FullScreenImageDialogFragment
@@ -41,6 +42,7 @@ internal class ImageFragment : BaseFragment<FragmentImageBinding, Image>() {
 
     override fun onViewCreated() {
         bucketId = arguments?.getLong(BUCKET_ID)
+        setRecyclerView(binding.rvImage)
         binding.rvImage.apply {
             adapter = imageAdapter
             setHasFixedSize(true)
@@ -63,10 +65,13 @@ internal class ImageFragment : BaseFragment<FragmentImageBinding, Image>() {
     }
 
     private fun updateImageList(imageList: List<Image>) {
+        if (viewModel.resultFlow.value is Result.Loading) {
+            return
+        }
         val isImageListEmpty = imageList.isEmpty()
         binding.rvImage.isVisible = !isImageListEmpty
         binding.textNoData.isVisible = isImageListEmpty
-        imageAdapter.addItemList(imageList)
+        imageAdapter.setItemList(imageList)
     }
 
     override fun handleSuccess(images: List<Image>) {
@@ -121,5 +126,9 @@ internal class ImageFragment : BaseFragment<FragmentImageBinding, Image>() {
     private fun showZoomImage(item: Image) {
         val imageDialogFragment = FullScreenImageDialogFragment.newInstance(item)
         imageDialogFragment.show(childFragmentManager, FullScreenImageDialogFragment.FRAGMENT_TAG)
+    }
+
+    override fun onConfigurationChange() {
+        setRecyclerView(binding.rvImage)
     }
 }

--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/util/PickerConfigManager.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/util/PickerConfigManager.kt
@@ -1,0 +1,41 @@
+package com.app.imagepickerlibrary.util
+
+import android.os.Bundle
+import androidx.core.os.bundleOf
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryOwner
+import com.app.imagepickerlibrary.EXTRA_IMAGE_PICKER_CONFIG
+import com.app.imagepickerlibrary.getModel
+import com.app.imagepickerlibrary.model.PickerConfig
+
+internal class PickerConfigManager(registryOwner: SavedStateRegistryOwner) :
+    SavedStateRegistry.SavedStateProvider {
+    companion object {
+        const val PICKER_CONFIG_MANAGER = "picker_config_manage"
+    }
+
+    private var pickerConfig = PickerConfig.defaultPicker()
+
+    init {
+        registryOwner.lifecycle.addObserver(LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_CREATE) {
+                val registry = registryOwner.savedStateRegistry
+                registry.registerSavedStateProvider(PICKER_CONFIG_MANAGER, this)
+                val previousState = registry.consumeRestoredStateForKey(PICKER_CONFIG_MANAGER)
+                if (previousState != null && previousState.containsKey(EXTRA_IMAGE_PICKER_CONFIG)) {
+                    pickerConfig = previousState.getModel() ?: PickerConfig.defaultPicker()
+                }
+            }
+        })
+    }
+
+    override fun saveState(): Bundle {
+        return bundleOf(EXTRA_IMAGE_PICKER_CONFIG to pickerConfig)
+    }
+
+    fun getPickerConfig(): PickerConfig {
+        return pickerConfig
+    }
+}

--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/util/Util.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/util/Util.kt
@@ -1,5 +1,6 @@
 package com.app.imagepickerlibrary.util
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -8,10 +9,12 @@ import android.graphics.Matrix
 import android.graphics.Paint
 import android.net.Uri
 import android.os.Build
+import android.os.ext.SdkExtensions.getExtensionVersion
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.exifinterface.media.ExifInterface
 import com.app.imagepickerlibrary.createImageFile
 import com.app.imagepickerlibrary.getRealPathFromURI
+import com.app.imagepickerlibrary.isNullOrEmptyOrBlank
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
@@ -26,13 +29,32 @@ internal fun isAtLeast13(): Boolean {
 }
 
 /**
+ * Utility function to check if system picker is available or not on Android 11+.
+ * The function is provided by google to check whether the photo picker is available or not
+ * [More Details](https://developer.android.com/training/data-storage/shared/photopicker#check-availability)
+ *
+ * Using SuppressLint to remove warning about the getExtensionVersion method.
+ */
+@SuppressLint("NewApi")
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.R)
+internal fun isPhotoPickerAvailable(): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        true
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        getExtensionVersion(Build.VERSION_CODES.R) >= 2
+    } else {
+        false
+    }
+}
+
+/**
  * Utility function to compress the image.
  * The function returns the file path of the compressed image.
  */
 @Suppress("DEPRECATION")
 internal fun compress(context: Context, uri: Uri, name: String, compressQuality: Int): String? {
     val filePath = context.getRealPathFromURI(uri)
-    if (filePath.isNullOrEmpty() || filePath.isBlank()) {
+    if (filePath.isNullOrEmptyOrBlank()) {
         return null
     }
     var scaledBitmap: Bitmap? = null

--- a/imagepickerlibrary/src/main/res/layout/fragment_folder.xml
+++ b/imagepickerlibrary/src/main/res/layout/fragment_folder.xml
@@ -18,7 +18,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:spanCount="?attr/ssPickerGridCount"
             tools:listitem="@layout/list_item_folder" />
 
         <com.google.android.material.progressindicator.CircularProgressIndicator

--- a/imagepickerlibrary/src/main/res/layout/fragment_image.xml
+++ b/imagepickerlibrary/src/main/res/layout/fragment_image.xml
@@ -18,7 +18,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:spanCount="?attr/ssPickerGridCount"
             tools:listitem="@layout/list_item_image" />
 
         <com.google.android.material.progressindicator.CircularProgressIndicator

--- a/imagepickerlibrary/src/main/res/values/attr.xml
+++ b/imagepickerlibrary/src/main/res/values/attr.xml
@@ -32,8 +32,10 @@
         <attr name="ssNoDataTextViewStyle" format="reference" />
         <!--The text which will be displayed to user as toast message when the user tries to select more images then the specified pick limit-->
         <attr name="ssImagePickerLimitText" format="string" />
-        <!--Grid count in picker screen. It will be same for both folder and the image-->
+        <!--Grid count in picker screen for portrait mode. It will be same for both folder and the image-->
         <attr name="ssPickerGridCount" format="integer" />
+        <!--Grid count in picker screen for landscape mode. It will be same for both folder and the image-->
+        <attr name="ssPickerGridCountLandscape" format="integer" />
         <!--The image drawable to indicate the image is selected. the icon is displayed over the selected image.-->
         <attr name="ssImageSelectIcon" format="reference" />
         <!--The icon which is used to open image in dialog mode to see in full view mode-->

--- a/imagepickerlibrary/src/main/res/values/themes.xml
+++ b/imagepickerlibrary/src/main/res/values/themes.xml
@@ -23,6 +23,7 @@
         <item name="ssNoDataTextViewStyle">@style/SSNoDataTextStyle</item>
         <item name="ssImagePickerLimitText">@string/str_picker_limit</item>
         <item name="ssPickerGridCount">2</item>
+        <item name="ssPickerGridCountLandscape">4</item>
         <item name="ssImageSelectIcon">@drawable/ic_ss_check_circle</item>
         <item name="ssImageZoomIcon">@drawable/ic_ss_zoom_eye</item>
         <item name="ssUCropToolbarColor">?attr/ssToolbarBackground</item>


### PR DESCRIPTION
Update image picker library with configuration changes, picker config changes, and bucket name changes.

Part -4 contains the files related to the new image picker library's modification and changes.

## Changes :
- :zap: Support for the device rotation configuration change.
- :zap: Picker config changes to limit max pick count, max size is in now float and a new way to register image picker.
- :sparkles: Support for new photo picker up to Android 11. [More details](https://developer.android.com/training/data-storage/shared/photopicker)

## Major File Changes:
:heavy_plus_sign: **Added**
- PickerConfigManager.kt - This class is the manager for the picker config. It extends SavedStateProvider to persist the picker config during activity configuration changes and process death.

:construction: **Modified**
- ImagePicker.kt - Added a new way to register for the ImagePicker and it's listener. Now the user needs to create the library before on create.
- ImagePickerViewModel.kt - Changed the MutableState flow to MutableSharedFlow. The state flow was causing issues in no data found as the same values cannot be emitted by state flow. 
- BaseFragment.kt - Modified base fragment to handle the configuration change. Rotation change will now display different grid span counts for recycler view.
- DataModels.kt - Included support for floating max size. Also, limits the max pick count to 15.
- attr.xml - Added an attribute **ssPickerGridCountLandscape** to represent grid count in landscape mode.
- Extension.kt - Added some important extensions to easily check, get and register tasks.

## :books: Usage:
1. Add ImagePickerActivity into your AndroidManifest.xml. **SSImagePicker** is the default theme for image picker activity.
```xml
<activity
    android:name="com.app.imagepickerlibrary.ui.activity.ImagePickerActivity"
    android:configChanges="orientation|screenSize"
    android:theme="@style/SSImagePicker" />
```

2. If you want to use Picker options Bottomsheet then implement **SSPickerOptionsBottomSheet.ImagePickerClickListener** in your fragment or activity. **onImageProvider** method will give the selected provider type.

```kotlin
    val pickerOptionBottomSheet = SSPickerOptionsBottomSheet.newInstance()
    pickerOptionBottomSheet.show(supportFragmentManager,"tag")
    ....
    override fun onImageProvider(provider: ImageProvider) {
        when (provider) {
            ImageProvider.GALLERY -> {
                //Open gallery
            }
            ImageProvider.CAMERA -> {
                //Open camera
            }
            ImageProvider.NONE -> {}
        }
    }
```

3. Open Image Picker from activity or fragment via registering the image picker. It will give the object of **ImagePicker** class.

```kotlin
    private val imagePicker: ImagePicker = registerImagePicker(callback = this)

    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        ...
    }
    
    //To Open the picker call the open method passing the picker type.
    imagePicker.open(PickerType.GALLERY)
```

4. Add customization to the image picker via the image picker object. All the methods with descriptions are declared inside **ImagePicker.kt** file.
```kotlin
    imagePicker
            .title("My Picker")
            .multipleSelection(enable = true, maxCount = 5)
            .showCountInToolBar(false)
            .showFolder(true)
            .cameraIcon(true)
            .doneIcon(true)
            .allowCropping(true)
            .compressImage(false)
            .maxImageSize(2)
            .extension(PickExtension.JPEG)
    imagePicker.open(PickerType.GALLERY)
```

5. To get results in activity or fragment implement **ImagePickerResultListener**.

```kotlin
    class MainActivity : AppCompatActivity(), ImagePickerResultListener {
        ...
    }
```
6. Single Selection and The image captured from the camera will be received in
   **onImagePick(uri: Uri?)** callback.
```kotlin
    override fun onImagePick(uri: Uri?) {
        //Do something with uri
    }
```
7. Multiple Selection uris will be received in **onMultiImagePick(uris: List<Uri>?)** callback.

```kotlin
    override fun onMultiImagePick(uris: List<Uri>?) {
        //Do something with uris
    }
```