### PR TITLE
:zap: Update build script and fix missing drawable file

### DIFF
--- a/imagepickerlibrary/build.gradle.kts
+++ b/imagepickerlibrary/build.gradle.kts
@@ -6,6 +6,20 @@ plugins {
     id("maven-publish")
 }
 
+afterEvaluate {
+    publishing {
+        publications {
+            register<MavenPublication>("release") {
+                groupId = "com.github.SimformSolutionsPvtLtd"
+                artifactId = "SSImagePicker"
+                version = "2.0"
+
+                from(components["release"])
+            }
+        }
+    }
+}
+
 android {
     compileSdk = 33
 
@@ -37,20 +51,6 @@ android {
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_11.toString()
-    }
-
-    afterEvaluate {
-        publishing {
-            publications {
-                register<MavenPublication>("release") {
-                    groupId = "com.github.SimformSolutionsPvtLtd"
-                    artifactId = "SSImagePicker"
-                    version = "2.0"
-
-                    from(components["release"])
-                }
-            }
-        }
     }
 }
 

--- a/imagepickerlibrary/src/main/res/layout/bottom_sheet_image_picker_options.xml
+++ b/imagepickerlibrary/src/main/res/layout/bottom_sheet_image_picker_options.xml
@@ -13,7 +13,6 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/ssSheetBackground"
         android:paddingBottom="@dimen/_4sdp">
 
         <androidx.appcompat.widget.AppCompatTextView

--- a/imagepickerlibrary/src/main/res/values/themes.xml
+++ b/imagepickerlibrary/src/main/res/values/themes.xml
@@ -94,7 +94,7 @@
     </style>
 
     <style name="SSRoundBottomSheet" parent="@style/Widget.Design.BottomSheet.Modal">
-        <item name="android:background">@drawable/drawable_bottom_sheet_dialog</item>
+        <item name="android:background">?attr/ssSheetBackground</item>
         <item name="android:windowIsFloating">false</item>
     </style>
 


### PR DESCRIPTION
## Changes

- Moved **`afterEvaluate`** block from **android** block to the root of the file.
- Fixed an issue of drawable file not available in theme.xml of picker library.