### PR TITLE
:zap: Update feature - New Picker Demo

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id(Plugins.ANDROID_APPLICATION)
     kotlin(Plugins.Kotlin.ANDROID)
     kotlin(Plugins.Kotlin.KAPT)
+    id(Plugins.Kotlin.PARCELIZE)
 }
 
 android {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:supportsRtl="true"
         android:theme="@style/SSImagePickerApp">
         <activity
-            android:name=".MainActivity"
+            android:name=".ui.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/ssimagepicker/app/PickerOptions.kt
+++ b/app/src/main/java/com/ssimagepicker/app/PickerOptions.kt
@@ -1,0 +1,44 @@
+package com.ssimagepicker.app
+
+import android.os.Parcelable
+import com.app.imagepickerlibrary.model.PickExtension
+import com.app.imagepickerlibrary.model.PickerType
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Data class to manage the picker options from bottom sheet to main activity.
+ */
+@Parcelize
+data class PickerOptions(
+    val pickerType: PickerType,
+    val showCountInToolBar: Boolean,
+    val showFolders: Boolean,
+    val allowMultipleSelection: Boolean,
+    val maxPickCount: Int,
+    val maxPickSizeMB: Float,
+    val pickExtension: PickExtension,
+    val showCameraIconInGallery: Boolean,
+    val isDoneIcon: Boolean,
+    val openCropOptions: Boolean,
+    val openSystemPicker: Boolean,
+    val compressImage: Boolean
+) : Parcelable {
+    companion object {
+        fun default(): PickerOptions {
+            return PickerOptions(
+                pickerType = PickerType.GALLERY,
+                showCountInToolBar = true,
+                showFolders = true,
+                allowMultipleSelection = false,
+                maxPickCount = 15,
+                maxPickSizeMB = 2.5f,
+                pickExtension = PickExtension.ALL,
+                showCameraIconInGallery = true,
+                isDoneIcon = true,
+                openCropOptions = false,
+                openSystemPicker = false,
+                compressImage = false
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ssimagepicker/app/ui/ImageDataAdapter.kt
+++ b/app/src/main/java/com/ssimagepicker/app/ui/ImageDataAdapter.kt
@@ -1,11 +1,13 @@
-package com.ssimagepicker.app
+package com.ssimagepicker.app.ui
 
 import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.ssimagepicker.app.R
 import com.ssimagepicker.app.databinding.ListItemImageDataBinding
+import com.ssimagepicker.app.loadImage
 
 /**
  * ImageDataAdapter class to display list of picked images from the picker.

--- a/app/src/main/java/com/ssimagepicker/app/ui/PickerOptionsBottomSheet.kt
+++ b/app/src/main/java/com/ssimagepicker/app/ui/PickerOptionsBottomSheet.kt
@@ -1,0 +1,179 @@
+package com.ssimagepicker.app.ui
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.os.bundleOf
+import com.app.imagepickerlibrary.model.PickExtension
+import com.app.imagepickerlibrary.model.PickerType
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.ssimagepicker.app.PickerOptions
+import com.ssimagepicker.app.R
+import com.ssimagepicker.app.databinding.BottomSheetPickerOptionsBinding
+
+/**
+ * PickerOptionsBottomSheet to display picker option related to new Image Picker.
+ */
+class PickerOptionsBottomSheet : BottomSheetDialogFragment(), View.OnClickListener {
+    companion object {
+        const val BOTTOM_SHEET_TAG = "PICKER_BOTTOM_SHEET_TAG"
+        const val PICKER_OPTIONS = "PICKER_OPTIONS"
+
+        fun newInstance(pickerOptions: PickerOptions): PickerOptionsBottomSheet {
+            val bundle = bundleOf(PICKER_OPTIONS to pickerOptions)
+            val pickerOptionsBottomSheet = PickerOptionsBottomSheet()
+            pickerOptionsBottomSheet.arguments = bundle
+            return pickerOptionsBottomSheet
+        }
+    }
+
+    private var mListener: PickerOptionsListener? = null
+    private lateinit var binding: BottomSheetPickerOptionsBinding
+
+    override fun getTheme(): Int {
+        return R.style.PickerOptionsBottomSheetDialog
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return BottomSheetDialog(requireContext(), this.theme)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        dialog?.setOnShowListener { dialog ->
+            val bottomSheetDialog = dialog as BottomSheetDialog
+            val bottomSheetInternal =
+                bottomSheetDialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) as View
+            BottomSheetBehavior.from(bottomSheetInternal).state =
+                BottomSheetBehavior.STATE_HALF_EXPANDED
+        }
+        binding = BottomSheetPickerOptionsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setUI()
+    }
+
+    /**
+     * Setting previously selected options with picker option object
+     */
+    private fun setUI() {
+        binding.apply {
+            clickHandler = this@PickerOptionsBottomSheet
+            val pickerOptions = arguments?.getParcelable(PICKER_OPTIONS) ?: PickerOptions.default()
+
+            val checkedPickerTypeId = if (pickerOptions.pickerType == PickerType.CAMERA) {
+                R.id.camera_button
+            } else {
+                R.id.gallery_button
+            }
+            pickerTypeGroup.check(checkedPickerTypeId)
+
+            multiSelectionSwitch.isChecked = pickerOptions.allowMultipleSelection
+            countToolbarSwitch.isChecked = pickerOptions.showCountInToolBar
+            folderSwitch.isChecked = pickerOptions.showFolders
+            cameraInGallery.isChecked = pickerOptions.showCameraIconInGallery
+            doneSwitch.isChecked = pickerOptions.isDoneIcon
+            openCropSwitch.isChecked = pickerOptions.openCropOptions
+            systemPickerSwitch.isChecked = pickerOptions.openSystemPicker
+            compressImageSwitch.isChecked = pickerOptions.compressImage
+
+            val checkedExtensionId = when (pickerOptions.pickExtension) {
+                PickExtension.PNG -> R.id.png_button
+                PickExtension.JPEG -> R.id.jpeg_button
+                PickExtension.WEBP -> R.id.webp_button
+                PickExtension.ALL -> R.id.all_button
+            }
+            extensionTypeGroup.check(checkedExtensionId)
+
+            pickCountSlider.valueFrom = 1f
+            pickCountSlider.valueTo = 15f
+            pickCountSlider.stepSize = 1f
+            pickCountSlider.value = pickerOptions.maxPickCount.toFloat()
+
+            if (pickerOptions.maxPickSizeMB != Float.MAX_VALUE) {
+                pickSizeTie.setText(pickerOptions.maxPickSizeMB.toString())
+            }
+        }
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        mListener = null
+    }
+
+    override fun onClick(v: View) {
+        when (v.id) {
+            R.id.done_text -> {
+                if (isDataValid()) {
+                    openImagePicker()
+                }
+            }
+        }
+    }
+
+    private fun openImagePicker() {
+        val countValue = binding.pickCountSlider.value.toInt()
+        val sizeValue = binding.pickSizeTie.text.toString().toFloat()
+        val pickExtension = when (binding.extensionTypeGroup.checkedButtonId) {
+            R.id.all_button -> PickExtension.ALL
+            R.id.png_button -> PickExtension.PNG
+            R.id.jpeg_button -> PickExtension.JPEG
+            R.id.webp_button -> PickExtension.WEBP
+            else -> PickExtension.ALL
+        }
+        val pickerType =
+            if (binding.pickerTypeGroup.checkedButtonId == R.id.gallery_button) {
+                PickerType.GALLERY
+            } else {
+                PickerType.CAMERA
+            }
+        val pickerOptions = PickerOptions(
+            pickerType = pickerType,
+            showCountInToolBar = binding.countToolbarSwitch.isChecked,
+            showFolders = binding.folderSwitch.isChecked,
+            allowMultipleSelection = binding.multiSelectionSwitch.isChecked,
+            maxPickCount = countValue,
+            maxPickSizeMB = sizeValue,
+            pickExtension = pickExtension,
+            showCameraIconInGallery = binding.cameraInGallery.isChecked,
+            isDoneIcon = binding.doneSwitch.isChecked,
+            openCropOptions = binding.openCropSwitch.isChecked,
+            openSystemPicker = binding.systemPickerSwitch.isChecked,
+            compressImage = binding.compressImageSwitch.isChecked
+        )
+        dismiss()
+        mListener?.onPickerOptions(pickerOptions)
+    }
+
+    /**
+     * Check whether the max pick count and max size is valid or not.
+     * If all data is valid it will return true.
+     */
+    private fun isDataValid(): Boolean {
+        val sizeValue = binding.pickSizeTie.text.toString().toFloatOrNull()
+        if (sizeValue == null || sizeValue <= 0) {
+            Toast.makeText(requireContext(), R.string.error_size_value, Toast.LENGTH_LONG).show()
+            return false
+        }
+        return true
+    }
+
+    fun setClickListener(listener: PickerOptionsListener) {
+        this.mListener = listener
+    }
+
+    interface PickerOptionsListener {
+        fun onPickerOptions(pickerOptions: PickerOptions)
+    }
+}

--- a/app/src/main/res/drawable/selector_button_text_color.xml
+++ b/app/src/main/res/drawable/selector_button_text_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/white" android:state_checked="true" android:state_enabled="true" />
+    <item android:color="@color/color_text" />
+</selector>

--- a/app/src/main/res/drawable/selector_switch_thumb.xml
+++ b/app/src/main/res/drawable/selector_switch_thumb.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/colorPrimary" android:state_checked="true" />
+    <item android:color="@color/white" />
+</selector>

--- a/app/src/main/res/drawable/selector_switch_track.xml
+++ b/app/src/main/res/drawable/selector_switch_track.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/colorAccent" android:state_checked="true" />
+    <item android:color="@color/gray" />
+</selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,260 +10,56 @@
             type="android.view.View.OnClickListener" />
     </data>
 
-    <ScrollView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fillViewport="true"
-        tools:context=".MainActivity">
+        android:paddingHorizontal="@dimen/_12sdp"
+        tools:context=".ui.MainActivity">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:paddingHorizontal="@dimen/_12sdp">
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/open_picker_button"
+            android:layout_marginTop="@dimen/_6sdp"
+            style="@style/ButtonSelectorStyle"
+            android:onClick="@{clickHandler::onClick}"
+            android:text="@string/open_image_picker"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/picker_type_text"
-                style="@style/TitleStyle"
-                android:text="@string/picker_type"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/open_sheet_button"
+            style="@style/ButtonSelectorStyle"
+            android:onClick="@{clickHandler::onClick}"
+            android:text="@string/open_picker_sheet"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/open_picker_button" />
 
-            <com.google.android.material.button.MaterialButtonToggleGroup
-                android:id="@+id/picker_type_group"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:checkedButton="@id/gallery_button"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/picker_type_text"
-                app:selectionRequired="true"
-                app:singleSelection="true">
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/options_button"
+            style="@style/ButtonSelectorStyle"
+            android:onClick="@{clickHandler::onClick}"
+            android:text="@string/customize_picker_options"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/open_sheet_button" />
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/gallery_button"
-                    style="@style/ButtonStyle"
-                    android:text="@string/str_gallery" />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/image_recycler_view"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="@dimen/_8sdp"
+            android:clipToPadding="false"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/_8sdp"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/options_button"
+            app:spanCount="2"
+            tools:itemCount="8"
+            tools:listitem="@layout/list_item_image_data" />
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/camera_button"
-                    style="@style/ButtonStyle"
-                    android:text="@string/str_camera" />
-
-            </com.google.android.material.button.MaterialButtonToggleGroup>
-
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/multi_selection_switch"
-                style="@style/SwitchStyle"
-                android:text="@string/allow_multi_selection"
-                app:layout_constraintEnd_toStartOf="@id/divider_1"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/picker_type_group" />
-
-            <View
-                android:id="@+id/divider_1"
-                style="@style/DividerStyle"
-                app:layout_constraintBottom_toBottomOf="@id/multi_selection_switch"
-                app:layout_constraintEnd_toStartOf="@id/count_toolbar_switch"
-                app:layout_constraintStart_toEndOf="@id/multi_selection_switch"
-                app:layout_constraintTop_toTopOf="@id/multi_selection_switch" />
-
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/count_toolbar_switch"
-                style="@style/SwitchStyle"
-                android:checked="true"
-                android:text="@string/show_count_in_toolbar"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/divider_1"
-                app:layout_constraintTop_toBottomOf="@id/picker_type_group" />
-
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/folder_switch"
-                style="@style/SwitchStyle"
-                android:checked="true"
-                android:text="@string/show_folder"
-                app:layout_constraintEnd_toStartOf="@id/divider_2"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/multi_selection_switch" />
-
-            <View
-                android:id="@+id/divider_2"
-                style="@style/DividerStyle"
-                app:layout_constraintBottom_toBottomOf="@id/folder_switch"
-                app:layout_constraintEnd_toStartOf="@id/camera_in_gallery"
-                app:layout_constraintStart_toEndOf="@id/folder_switch"
-                app:layout_constraintTop_toTopOf="@id/folder_switch" />
-
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/camera_in_gallery"
-                style="@style/SwitchStyle"
-                android:checked="true"
-                android:text="@string/camera_icon_in_gallery"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/divider_2"
-                app:layout_constraintTop_toBottomOf="@id/multi_selection_switch" />
-
-
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/done_switch"
-                style="@style/SwitchStyle"
-                android:checked="true"
-                android:text="@string/done_icon"
-                app:layout_constraintEnd_toStartOf="@id/divider_3"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/folder_switch" />
-
-            <View
-                android:id="@+id/divider_3"
-                style="@style/DividerStyle"
-                app:layout_constraintBottom_toBottomOf="@id/done_switch"
-                app:layout_constraintEnd_toStartOf="@id/open_crop_switch"
-                app:layout_constraintStart_toEndOf="@id/done_switch"
-                app:layout_constraintTop_toTopOf="@id/done_switch" />
-
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/open_crop_switch"
-                style="@style/SwitchStyle"
-                android:text="@string/enable_crop"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/divider_3"
-                app:layout_constraintTop_toBottomOf="@id/folder_switch" />
-
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/system_picker_switch"
-                style="@style/SwitchStyle"
-                android:text="@string/system_picker"
-                app:layout_constraintEnd_toStartOf="@id/divider_4"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/done_switch" />
-
-            <View
-                android:id="@+id/divider_4"
-                style="@style/DividerStyle"
-                app:layout_constraintBottom_toBottomOf="@id/system_picker_switch"
-                app:layout_constraintEnd_toStartOf="@id/compress_image_switch"
-                app:layout_constraintStart_toEndOf="@id/system_picker_switch"
-                app:layout_constraintTop_toTopOf="@id/system_picker_switch" />
-
-            <com.google.android.material.switchmaterial.SwitchMaterial
-                android:id="@+id/compress_image_switch"
-                style="@style/SwitchStyle"
-                android:text="@string/compress_image"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/divider_4"
-                app:layout_constraintTop_toBottomOf="@id/done_switch" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/pick_count_text"
-                style="@style/TitleStyle"
-                android:text="@string/pick_count"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/system_picker_switch" />
-
-            <com.google.android.material.slider.Slider
-                android:id="@+id/pick_count_slider"
-                android:layout_width="0dp"
-                android:value="5"
-                android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/pick_count_text" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/pick_size_til"
-                style="@style/TextInputLayoutStyle"
-                android:hint="@string/max_size_mb"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/pick_count_slider">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/pick_size_tie"
-                    style="@style/EditTextStyle"
-                    android:imeOptions="actionDone"
-                    android:text="2.5" />
-
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/extension_type_text"
-                style="@style/TitleStyle"
-                android:text="@string/extension"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/pick_size_til" />
-
-            <com.google.android.material.button.MaterialButtonToggleGroup
-                android:id="@+id/extension_type_group"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:checkedButton="@id/all_button"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/extension_type_text"
-                app:selectionRequired="true"
-                app:singleSelection="true">
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/all_button"
-                    style="@style/ButtonStyle"
-                    android:text="@string/all" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/png_button"
-                    style="@style/ButtonStyle"
-                    android:text="@string/png" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/jpeg_button"
-                    style="@style/ButtonStyle"
-                    android:text="@string/jpeg" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/webp_button"
-                    style="@style/ButtonStyle"
-                    android:text="@string/webp" />
-
-            </com.google.android.material.button.MaterialButtonToggleGroup>
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/open_sheet_button"
-                style="@style/ButtonStyle"
-                android:layout_marginTop="@dimen/_6sdp"
-                android:layout_marginEnd="@dimen/_8sdp"
-                android:onClick="@{clickHandler::onClick}"
-                android:text="@string/open_picker_sheet"
-                app:layout_constraintEnd_toStartOf="@id/open_picker_button"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/extension_type_group" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/open_picker_button"
-                style="@style/ButtonStyle"
-                android:layout_marginStart="@dimen/_8sdp"
-                android:layout_marginTop="@dimen/_6sdp"
-                android:onClick="@{clickHandler::onClick}"
-                android:text="@string/open_image_picker"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/open_sheet_button"
-                app:layout_constraintTop_toBottomOf="@id/extension_type_group" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/image_recycler_view"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/_120sdp"
-                android:layout_marginTop="@dimen/_12sdp"
-                android:layout_marginBottom="@dimen/_24sdp"
-                android:orientation="horizontal"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/open_picker_button"
-                tools:itemCount="5"
-                tools:listitem="@layout/list_item_image_data" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </ScrollView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/bottom_sheet_picker_options.xml
+++ b/app/src/main/res/layout/bottom_sheet_picker_options.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="clickHandler"
+            type="android.view.View.OnClickListener" />
+    </data>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true"
+        tools:context=".ui.MainActivity">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:paddingHorizontal="@dimen/_12sdp">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/title"
+                style="@style/TitleStyle"
+                android:gravity="center"
+                android:text="@string/picker_options"
+                android:textSize="@dimen/_17ssp"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/done_text"
+                style="@style/TitleStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="0dp"
+                android:onClick="@{clickHandler::onClick}"
+                android:text="@string/done"
+                android:textSize="@dimen/_12ssp"
+                app:layout_constraintBottom_toBottomOf="@id/title"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/title" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/picker_type_text"
+                style="@style/TitleStyle"
+                android:text="@string/picker_type"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/title" />
+
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/picker_type_group"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:checkedButton="@id/gallery_button"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/picker_type_text"
+                app:selectionRequired="true"
+                app:singleSelection="true">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/gallery_button"
+                    style="@style/ButtonSelectorStyle"
+                    android:text="@string/str_gallery" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/camera_button"
+                    style="@style/ButtonSelectorStyle"
+                    android:text="@string/str_camera" />
+
+            </com.google.android.material.button.MaterialButtonToggleGroup>
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/multi_selection_switch"
+                style="@style/SwitchStyle"
+                android:text="@string/allow_multi_selection"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/picker_type_group" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/count_toolbar_switch"
+                style="@style/SwitchStyle"
+                android:checked="true"
+                android:text="@string/show_count_in_toolbar"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/multi_selection_switch" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/folder_switch"
+                style="@style/SwitchStyle"
+                android:checked="true"
+                android:text="@string/show_folder"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/count_toolbar_switch" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/camera_in_gallery"
+                style="@style/SwitchStyle"
+                android:checked="true"
+                android:text="@string/camera_icon_in_gallery"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/folder_switch" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/done_switch"
+                style="@style/SwitchStyle"
+                android:checked="true"
+                android:text="@string/done_icon"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/camera_in_gallery" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/open_crop_switch"
+                style="@style/SwitchStyle"
+                android:text="@string/enable_crop"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/done_switch" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/system_picker_switch"
+                style="@style/SwitchStyle"
+                android:text="@string/system_picker"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/open_crop_switch" />
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/compress_image_switch"
+                style="@style/SwitchStyle"
+                android:text="@string/compress_image"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/system_picker_switch" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/pick_count_text"
+                style="@style/TitleStyle"
+                android:text="@string/pick_count"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/compress_image_switch" />
+
+            <com.google.android.material.slider.Slider
+                android:id="@+id/pick_count_slider"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:value="5"
+                android:valueFrom="1"
+                android:valueTo="15"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/pick_count_text"
+                tools:ignore="SpeakableTextPresentCheck" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/pick_size_til"
+                style="@style/TextInputLayoutStyle"
+                android:hint="@string/max_size_mb"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/pick_count_slider">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/pick_size_tie"
+                    style="@style/EditTextStyle"
+                    android:imeOptions="actionDone" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/extension_type_text"
+                style="@style/TitleStyle"
+                android:text="@string/extension"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/pick_size_til" />
+
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/extension_type_group"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/_12sdp"
+                app:checkedButton="@id/all_button"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/extension_type_text"
+                app:selectionRequired="true"
+                app:singleSelection="true">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/all_button"
+                    style="@style/ButtonSelectorStyle"
+                    android:text="@string/all" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/png_button"
+                    style="@style/ButtonSelectorStyle"
+                    android:text="@string/png" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/jpeg_button"
+                    style="@style/ButtonSelectorStyle"
+                    android:text="@string/jpeg" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/webp_button"
+                    style="@style/ButtonSelectorStyle"
+                    android:text="@string/webp" />
+
+            </com.google.android.material.button.MaterialButtonToggleGroup>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
+</layout>

--- a/app/src/main/res/layout/list_item_image_data.xml
+++ b/app/src/main/res/layout/list_item_image_data.xml
@@ -4,9 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/_8sdp">
+        android:layout_marginVertical="@dimen/_4sdp">
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/image_view"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -2,4 +2,5 @@
 <resources>
     <color name="color_text">#FFFFFF</color>
     <color name="color_bottom_sheet_bg">#222222</color>
+    <color name="button_stroke_color">@color/black</color>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -27,13 +27,4 @@
         <item name="boxStrokeColor">@color/white</item>
         <item name="android:textColorHint">@color/white</item>
     </style>
-
-    <style name="ButtonStyle" parent="Widget.MaterialComponents.Button.OutlinedButton">
-        <item name="android:layout_width">0dp</item>
-        <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_weight">1</item>
-        <item name="strokeColor">@color/black</item>
-        <item name="android:textColor">@color/white</item>
-        <item name="backgroundTint">@drawable/selector_button_bg</item>
-    </style>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!--<color name="colorPrimary">#2D647D</color>
+    <color name="colorPrimary">#2D647D</color>
     <color name="colorPrimaryDark">#2D647D</color>
-    <color name="colorAccent">#46a0c6</color>-->
-
-    <color name="colorPrimary">#326267</color>
-    <color name="colorPrimaryDark">#194F54</color>
-    <color name="colorAccent">#D9FEF2</color>
-
+    <color name="colorAccent">#46A0C6</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="color_bg">#D9FEF2</color>
-    <color name="color_bottom_sheet_bg">#ecfff9</color>
+    <color name="color_bottom_sheet_bg">#FFFFFF</color>
     <color name="color_text">#194F54</color>
     <color name="color_cancel_text">#6F7B7A</color>
+    <color name="gray">#808080</color>
+    <color name="button_stroke_color">@color/colorPrimary</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,8 +20,11 @@
     <string name="png">PNG</string>
     <string name="jpeg">JPEG</string>
     <string name="webp">WEBP</string>
-    <string name="open_picker_sheet">Open picker choose sheet</string>
+    <string name="open_picker_sheet">Choose Picker Type</string>
     <string name="open_image_picker">Open image picker</string>
     <string name="error_count_value">Enter valid max count value. It should be greater than 0.</string>
     <string name="error_size_value">Enter valid max size value. It should be greater than 0.</string>
+    <string name="customize_picker_options">Customize Picker Options</string>
+    <string name="picker_options">Picker Options</string>
+    <string name="done">Done</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -38,10 +38,11 @@
     <style name="SwitchStyle">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_marginTop">@dimen/_8sdp</item>
+        <item name="android:layout_marginTop">@dimen/_4sdp</item>
         <item name="android:textAppearance">@style/TextAppearance.MaterialComponents.Button</item>
         <item name="android:textColor">@color/color_text</item>
-        <item name="switchPadding">@dimen/_5sdp</item>
+        <item name="thumbTint">@drawable/selector_switch_thumb</item>
+        <item name="trackTint">@drawable/selector_switch_track</item>
     </style>
 
     <style name="DividerStyle">
@@ -88,10 +89,24 @@
         <item name="android:textSize">@dimen/_14ssp</item>
     </style>
 
-    <style name="ButtonStyle" parent="Widget.MaterialComponents.Button.OutlinedButton">
+    <style name="ButtonSelectorStyle" parent="Widget.MaterialComponents.Button.OutlinedButton">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_weight">1</item>
+        <item name="strokeColor">@color/button_stroke_color</item>
+        <item name="android:textColor">@drawable/selector_button_text_color</item>
+        <item name="backgroundTint">@drawable/selector_button_bg</item>
+    </style>
+
+    <style name="PickerOptionsBottomSheetDialog" parent="@style/Theme.MaterialComponents.Light.BottomSheetDialog">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryVariant">@color/colorPrimaryDark</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <item name="bottomSheetStyle">@style/RoundCornerBottomSheet</item>
+    </style>
+
+    <style name="RoundCornerBottomSheet" parent="@style/Widget.Design.BottomSheet.Modal">
+        <item name="android:background">@drawable/drawable_bottom_sheet_dialog</item>
     </style>
 
 </resources>

--- a/buildSrc/src/main/kotlin/Plugins.kt
+++ b/buildSrc/src/main/kotlin/Plugins.kt
@@ -4,5 +4,6 @@ object Plugins {
     object Kotlin {
         const val ANDROID = "android"
         const val KAPT = "kapt"
+        const val PARCELIZE = "kotlin-parcelize"
     }
 }


### PR DESCRIPTION
Update the ImagePicker demo with a new theme and all the supported functionality with picker UI modifications.

## Update Features :

- :sparkles: New image picker demo with all customizable methods.
- :sparkles: Custom UI support to demonstrate usage of UI attributes of picker screen in your own custom layout.

## Major File Changes:
:heavy_plus_sign: **Added**
- PickerOptionsBottomSheet.kt - Added picker options bottom sheet to display all the configuration options of the image picker.

:construction: **Modified**
- themes.xml - Modified themes file to add custom attributes related to the picker demo screen. The demo screen theme is modified for both light and dark modes.
- build.gradle.kts **(app)** -  Added parcelize kotlin plugin.

## :books: Usage:
* You can run the demo. Open the picker configuration bottom sheet and turn on the specific switch to enable a particular feature. Also, there is support for max pick count via slider and max size via input. All the selected images will be displayed at the bottom of the demo screen buttons.