### PR TITLE
Request Feature : Aspect Ratio Crop

### DIFF
--- a/app/src/main/java/com/ssimagepicker/app/PickerOptions.kt
+++ b/app/src/main/java/com/ssimagepicker/app/PickerOptions.kt
@@ -1,6 +1,7 @@
 package com.ssimagepicker.app
 
 import android.os.Parcelable
+import com.app.imagepickerlibrary.model.AspectRatio
 import com.app.imagepickerlibrary.model.PickExtension
 import com.app.imagepickerlibrary.model.PickerType
 import kotlinx.parcelize.Parcelize
@@ -21,7 +22,8 @@ data class PickerOptions(
     val isDoneIcon: Boolean,
     val openCropOptions: Boolean,
     val openSystemPicker: Boolean,
-    val compressImage: Boolean
+    val compressImage: Boolean,
+    var aspectRatio: AspectRatio?
 ) : Parcelable {
     companion object {
         fun default(): PickerOptions {
@@ -37,7 +39,8 @@ data class PickerOptions(
                 isDoneIcon = true,
                 openCropOptions = false,
                 openSystemPicker = false,
-                compressImage = false
+                compressImage = false,
+                aspectRatio = null
             )
         }
     }

--- a/app/src/main/java/com/ssimagepicker/app/ui/MainActivity.kt
+++ b/app/src/main/java/com/ssimagepicker/app/ui/MainActivity.kt
@@ -121,6 +121,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener,
             .compressImage(pickerOptions.compressImage)
             .maxImageSize(pickerOptions.maxPickSizeMB)
             .extension(pickerOptions.pickExtension)
+            .aspectRatio(pickerOptions.aspectRatio)
         if (isAtLeast11()) {
             imagePicker.systemPicker(pickerOptions.openSystemPicker)
         }

--- a/app/src/main/java/com/ssimagepicker/app/ui/PickerOptionsBottomSheet.kt
+++ b/app/src/main/java/com/ssimagepicker/app/ui/PickerOptionsBottomSheet.kt
@@ -150,7 +150,8 @@ class PickerOptionsBottomSheet : BottomSheetDialogFragment(), View.OnClickListen
             isDoneIcon = binding.doneSwitch.isChecked,
             openCropOptions = binding.openCropSwitch.isChecked,
             openSystemPicker = binding.systemPickerSwitch.isChecked,
-            compressImage = binding.compressImageSwitch.isChecked
+            compressImage = binding.compressImageSwitch.isChecked,
+            aspectRatio = null
         )
         dismiss()
         mListener?.onPickerOptions(pickerOptions)

--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ImagePicker.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ImagePicker.kt
@@ -9,6 +9,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import com.app.imagepickerlibrary.listener.ImagePickerResultListener
+import com.app.imagepickerlibrary.model.AspectRatio
 import com.app.imagepickerlibrary.model.PickExtension
 import com.app.imagepickerlibrary.model.PickerType
 import com.app.imagepickerlibrary.ui.activity.ImagePickerActivity
@@ -122,6 +123,16 @@ class ImagePicker private constructor(
     fun doneIcon(enable: Boolean): ImagePicker {
         pickerConfigManager.getPickerConfig().isDoneIcon = enable
         return this
+    }
+
+    /**
+     * Pass the AspectRatio and user will have to select the image in specified aspect Ratio
+     * Note:If you use the `aspectRatio`, the `openCropOption` will be ignored.
+     * By default, `aspectRatio` is set to `null`. If you want to allow users to choose
+     * crop options manually via `openCropOption`, ensure that `aspectRatio` remains `null`.
+     */
+    fun aspectRatio(aspectRatio: AspectRatio?) {
+        pickerConfigManager.getPickerConfig().aspectRatio = aspectRatio
     }
 
     /**

--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/model/DataModels.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/model/DataModels.kt
@@ -26,7 +26,8 @@ internal data class PickerConfig(
     var openCropOptions: Boolean = false,
     var openSystemPicker: Boolean = false,
     var compressImage: Boolean = false,
-    var compressQuality: Int = 75
+    var compressQuality: Int = 75,
+    var aspectRatio: AspectRatio? = null
 ) : Parcelable {
 
     companion object {
@@ -127,3 +128,6 @@ internal sealed class Result<out R> {
     data class Error(val exception: Exception) : Result<Nothing>()
     data object Loading : Result<Nothing>()
 }
+
+@Parcelize
+data class AspectRatio(val x: Float, val y : Float): Parcelable

--- a/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/activity/ImagePickerActivity.kt
+++ b/imagepickerlibrary/src/main/java/com/app/imagepickerlibrary/ui/activity/ImagePickerActivity.kt
@@ -251,7 +251,7 @@ class ImagePickerActivity : AppCompatActivity(), View.OnClickListener {
         }
 
     private fun checkForCropping(imageUri: Uri) {
-        if (pickerConfig.openCropOptions || pickerConfig.compressImage) {
+        if (pickerConfig.openCropOptions || pickerConfig.compressImage || pickerConfig.aspectRatio != null) {
             val date =
                 SimpleDateFormat(dateFormatForTakePicture, Locale.getDefault()).format(Date())
             val imageFile = createImageFile(date)
@@ -267,6 +267,11 @@ class ImagePickerActivity : AppCompatActivity(), View.OnClickListener {
      * Cropping option for the crop screen. Changing colors and setting ui controls.
      */
     private fun getUCropOptions(): UCrop.Options {
+        pickerConfig.aspectRatio?.let { aspectRatio ->
+            return UCrop.Options().apply {
+                withAspectRatio(aspectRatio.x, aspectRatio.y)
+            }
+        }
         return UCrop.Options().apply {
             setFreeStyleCropEnabled(pickerConfig.openCropOptions)
             setHideBottomControls(!pickerConfig.openCropOptions)


### PR DESCRIPTION
Feature Requested: https://github.com/SimformSolutionsPvtLtd/SSImagePicker/issues/62

Use the aspectRatio function to restrict image selection to a specific aspect ratio.

Note:  If you use the `aspectRatio`, the `openCropOption` will be ignored. By default, `aspectRatio` is set to `null`. If you want to allow users to choose crop options manually via `openCropOption`, ensure that `aspectRatio` remains `null`.