### PR TITLE
Provide dark theme support

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -3,4 +3,6 @@
     <color name="color_text">#FFFFFF</color>
     <color name="color_bottom_sheet_bg">#222222</color>
     <color name="button_stroke_color">@color/black</color>
+    <color name="no_content_text_color">@color/white</color>
+    <color name="picker_background">@color/white</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,4 +9,6 @@
     <color name="color_text">#194F54</color>
     <color name="gray">#808080</color>
     <color name="button_stroke_color">@color/colorPrimary</color>
+    <color name="no_content_text_color">@color/black</color>
+    <color name="picker_background">@color/white</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -15,12 +15,18 @@
         <item name="ssToolbarDoneTextAppearance">@style/CustomDoneTextAppearance</item>
         <item name="ssPickerGridCountLandscape">3</item>
         <item name="ssImageSelectIcon">@drawable/ic_baseline_check_circle</item>
+        <item name="ssPickerBackground">@color/picker_background</item>
+        <item name="ssNoDataTextViewStyle">@style/CustomNoDataTextStyle</item>
     </style>
 
     <style name="CustomDoneTextAppearance" parent="SSToolbarDoneTextAppearance">
         <item name="android:textColor">@color/black</item>
         <item name="android:textSize">@dimen/_13ssp</item>
         <item name="android:fontFamily">@font/poppins_medium</item>
+    </style>
+
+    <style name="CustomNoDataTextStyle" parent="SSNoDataTextStyle">
+        <item name="android:textColor">@color/no_content_text_color</item>
     </style>
 
     <style name="CustomPickerBottomSheet" parent="SSImagePickerBaseBottomSheetDialog">


### PR DESCRIPTION
This pull request introduces changes to improve the appearance and theming of the app's UI components, particularly for the image picker and "no content" views. It adds new color resources and styles to enhance customization and consistency across light and dark themes.

### Theme and Style Updates:
* [`app/src/main/res/values/themes.xml`](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffR18-R19): Added new style attributes `ssPickerBackground` and `ssNoDataTextViewStyle` to customize the background and "no content" text appearance for the image picker.
* [`app/src/main/res/values/themes.xml`](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffR28-R31): Introduced `CustomNoDataTextStyle` to define a specific text color for "no content" views using the newly added `no_content_text_color`.

### Color Resource Additions:
* [`app/src/main/res/values-night/colors.xml`](diffhunk://#diff-440377ff0ddd72c64376d35815c120ea2b47cdf1363a74b9c8d71d2ea6126c8dR6-R7): Added `no_content_text_color` and `picker_background` for dark theme compatibility.
* [`app/src/main/res/values/colors.xml`](diffhunk://#diff-d21b36fc9e8a3dfabd930b6500fba09e4199283a9c1783b6fe599a9d1433d04fR12-R13): Added `no_content_text_color` and `picker_background` for light theme compatibility.